### PR TITLE
Update LiNDDA default parameters and activate ONCET threshold method

### DIFF
--- a/dynasd/LiNDDA.py
+++ b/dynasd/LiNDDA.py
@@ -178,8 +178,8 @@ class LiNDDA(NDDBase):
 
     def __init__(self, 
                  fs=256,
-                 sequence_length=16, 
-                 forecast_length=16,
+                 sequence_length=3, 
+                 forecast_length=2,
                  w_size=1, 
                  w_stride=0.5,
                  num_epochs=10,

--- a/dynasd/ONCET.py
+++ b/dynasd/ONCET.py
@@ -405,8 +405,8 @@ class ONCET(DynaSDBase):
         # Should return a tensor of shape (nwins, 1, win_len_idx)
         return torch.from_numpy(data_flat).float().to(self.device)
 
-def get_pretrained_threshold():
-    """
-    Get pretrained threshold for ONCET model.
-    """
-    return 0.5
+    def _get_pretrained_threshold(self):
+        """
+        Get pretrained threshold for ONCET model.
+        """
+        return 0.62 # Learned from subset of validation dataset in DynaSD paper to optimize F1 score.


### PR DESCRIPTION
## Summary
- Update default parameters in `dynasd/LiNDDA.py`
- Activate ONCET threshold method in `dynasd/ONCET.py` with the correct function name

## Test plan
- [ ] Verify LiNDDA defaults produce expected behavior
- [ ] Verify ONCET threshold method runs end-to-end with the renamed function

🤖 Generated with [Claude Code](https://claude.com/claude-code)